### PR TITLE
fixed for use with contact form 7 4.8

### DIFF
--- a/cf7-dynamic-select.php
+++ b/cf7-dynamic-select.php
@@ -39,7 +39,7 @@
 		
 		public function shortcode_handler($tag) {
 			// generates html for form field
-			if (!is_array($tag)) {
+			if (!is_a($tag, 'WPCF7_FormTag')) {
 				return '';
 			}
 			$name = $tag['name'];

--- a/cf7-dynamic-select.php
+++ b/cf7-dynamic-select.php
@@ -39,7 +39,7 @@
 		
 		public function shortcode_handler($tag) {
 			// generates html for form field
-			if (!is_a($tag, 'WPCF7_FormTag')) {
+			if (!is_a($tag, 'WPCF7_FormTag') || !is_array($tag)) {
 				return '';
 			}
 			$name = $tag['name'];


### PR DESCRIPTION
Your $tag is now an instance of WPCF7_FormTag class, which implements ArrayAccess interface.

https://contactform7.com/2017/06/01/contact-form-7-48/#more-22829